### PR TITLE
Fixing typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ serve-latest-model:
 .PHONY: vertex-create-pipeline
 vertex-create-pipeline:
 	@echo "Create Vertex AI Pipeline"
-	tfx pipeline create --pipeline-path=./componens/model/bert/vertex_pipeline/vertex_dag_runner.py  --engine=vertex --build-image
+	tfx pipeline create --pipeline-path=./components/model/bert/vertex_pipeline/vertex_dag_runner.py  --engine=vertex --build-image
 
 .PHONY: vertex-update-pipeline
 vertex-update-pipeline:


### PR DESCRIPTION
There's a T missing in components for the Create Vertex AI pipeline make line